### PR TITLE
Fixes errors on Training and Validation solution notebooks

### DIFF
--- a/tutorial_notebooks/solutions/training_solution.ipynb
+++ b/tutorial_notebooks/solutions/training_solution.ipynb
@@ -274,7 +274,7 @@
     "# data loading (we are using a predefined method called load_dataset, which is part of the DL-ARC feature stack)\n",
     "X, y, num_classes, class_names, sampling_rate, has_null = load_dataset('rwhar_3sbjs', include_null=True)\n",
     "# since the method returns features and labels separatley, we need to concat them\n",
-    "data = np.concatenate((X, y[:, None]), axis=1)\n",
+    "data = np.concatenate((X, np.array(y)[:, None]), axis=1)\n",
     "\n",
     "# define the train data to be all data belonging to the first two subjects\n",
     "train_data = data[data[:, 0] <= 1]\n",

--- a/tutorial_notebooks/solutions/validation_and_testing_solution.ipynb
+++ b/tutorial_notebooks/solutions/validation_and_testing_solution.ipynb
@@ -163,7 +163,7 @@
     "# data loading (we are using a predefined method called load_dataset, which is part of the DL-ARC feature stack)\n",
     "X, y, num_classes, class_names, sampling_rate, has_null = load_dataset('rwhar_3sbjs', include_null=True)\n",
     "# since the method returns features and labels separatley, we need to concat them\n",
-    "data = np.concatenate((X, y[:, None]), axis=1)\n",
+    "data = np.concatenate((X, np.array(y)[:, None]), axis=1)\n",
     "\n",
     "# define the train data to be the data of the first subject\n",
     "train_data = data[data[:, 0] == 0]\n",
@@ -257,7 +257,8 @@
     "    'early_stopping': False,\n",
     "    'es_patience': 5,\n",
     "    'save_test_preds': False,\n",
-    "    'valid_epoch': 'last'\n",
+    "    'valid_epoch': 'last',\n",
+    "    'shuffling': True\n",
     "}"
    ]
   },
@@ -495,7 +496,7 @@
     "\n",
     "# define the stratified k-fold object; it is already imported for you\n",
     "# pass it the number of splits, i.e. folds, and seed as well as set shuffling to true\n",
-    "skf = StratifiedKFold(n_splits=config['splits_kfold'], random_state=config['seed'])\n",
+    "skf = StratifiedKFold(n_splits=config['splits_kfold'], shuffle=config['shuffling'], random_state=config['seed'])\n",
     "    \n",
     "print(train_valid_data.shape)\n",
     "\n",


### PR DESCRIPTION
`tutorial_notebooks/solutions/training_solution.ipynb` has the following error:

`ValueError: Multi-dimensional indexing (e.g. `obj[:, None]`) is no longer supported. Convert to a numpy array before indexing instead.`

Caused by this line: 

`data = np.concatenate((X, y[:, None]), axis=1)`

Which can be fixed by converting y to a NumPy array before indexing:

`data = np.concatenate((X, np.array(y)[:, None]), axis=1)`

-------------------------------

`tutorial_notebooks/solutions/validation_and_testing_solution.ipynb` has the same error described above, so the same fix was applied.

Additionally, the notebook has the following error:

`ValueError: Setting a random_state has no effect since shuffle is False. You should leave random_state to its default (None), or set shuffle=True.`

Caused by line:

`skf = StratifiedKFold(n_splits=config['splits_kfold'], random_state=config['seed'])`

Which can be fixed by directly adding `shuffle=True` as an argument, but as the notebook suggests using the config object, an entry was added to its end as `'shuffling': True\n",` and entered as an argument as `shuffle=config['shuffling']` as:

`skf = StratifiedKFold(n_splits=config['splits_kfold'], shuffle=config['shuffling'], random_state=config['seed'])`
